### PR TITLE
Cleanup launch files and parameterize bonsai concepts

### DIFF
--- a/package_template/package_template/policy_connection.py
+++ b/package_template/package_template/policy_connection.py
@@ -29,9 +29,9 @@ class PolicyConnection(BonsasiROSBase):
         # Initialize node timer
         self.event_timer = self.create_timer(
             0.250,  # unit: s
-            self.post_state_data)
+            self.command_with_policy)
 
-    def post_state_data(self):
+    def command_with_policy(self):
 
         # Set the request variables
         requestBody = {

--- a/samples/turtlebot3_bonsai/launch/policy_with_sim.launch.py
+++ b/samples/turtlebot3_bonsai/launch/policy_with_sim.launch.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python3
-#
-# Copyright 2019 ROBOTIS CO., LTD.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Authors: Darby Lim
 
 import os
 

--- a/samples/turtlebot3_bonsai/launch/policy_without_sim.launch.py
+++ b/samples/turtlebot3_bonsai/launch/policy_without_sim.launch.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python3
-#
-# Copyright 2019 ROBOTIS CO., LTD.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Authors: Darby Lim
 
 import os
 

--- a/samples/turtlebot3_bonsai/launch/racetrack.launch.py
+++ b/samples/turtlebot3_bonsai/launch/racetrack.launch.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python3
-#
-# Copyright 2019 ROBOTIS CO., LTD.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Authors: Darby Lim
 
 import os
 

--- a/samples/turtlebot3_bonsai/launch/small_house.launch.py
+++ b/samples/turtlebot3_bonsai/launch/small_house.launch.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python3
-#
-# Copyright 2019 ROBOTIS CO., LTD.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Authors: Darby Lim
 
 import os
 

--- a/samples/turtlebot3_bonsai/launch/warehouse.launch.py
+++ b/samples/turtlebot3_bonsai/launch/warehouse.launch.py
@@ -1,20 +1,4 @@
 #!/usr/bin/env python3
-#
-# Copyright 2019 ROBOTIS CO., LTD.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-# Authors: Darby Lim
 
 import os
 

--- a/samples/turtlebot3_bonsai/turtlebot3_bonsai/turtlebot3_bonsai_connection.py
+++ b/samples/turtlebot3_bonsai/turtlebot3_bonsai/turtlebot3_bonsai_connection.py
@@ -12,7 +12,6 @@ from nav_msgs.msg import Odometry
 
 class TurtleBot3BonsaiConnection(Node):
     def __init__(self, node_name):
-        # Calls Node.__init__('listener')
         super().__init__(node_name)
 
         # constants


### PR DESCRIPTION
* renamed method turtlebot3_policy_connection.post_state_data() to turtlebot3_policy_connection.command_with_policy() to make the behavior more intuitive
* removed author information from customized launch files that were originally copied from the turtlebot3 repository
* changed some logging levels from info to debug to reduce terminal clutter
* made concept_name a class parameter to turtlebot3_policy_connection - users will likely have unique names for their bonsai policies and the code should be flexible to that 